### PR TITLE
Bump version to 1.5

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = slock-royarg-git
 	pkgdesc = A modified version of the simple X display locker.
-	pkgver = 1.4.r17.e0e0fff
+	pkgver = 1.5.r0.36cbb5d
 	pkgrel = 1
 	url = https://github.com/RoyARG02/slock
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="slock"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.4.r17.e0e0fff
+pkgver=1.5.r0.36cbb5d
 pkgrel=1
 pkgdesc="A modified version of the simple X display locker."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 36cbb5d6e3a4ea10beb5197ae06905c8f5f5235d
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Oct 22 13:30:44 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit 4f045545a25cc02c64bfc08d27ed2ccecb962292
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Tue Oct 4 19:45:14 2022 +0200

        bump version to 1.5

    commit 265704d73647e0d4823126bbb7ddde1d415a618d
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Tue Oct 4 19:44:47 2022 +0200

        Makefile: explicit_bzero.c was copied twice (GNU make gives a warning)